### PR TITLE
Prevent browser caching after crop

### DIFF
--- a/Doctrine/ORM/EventSubscriber/ImageUploadSubscriber.php
+++ b/Doctrine/ORM/EventSubscriber/ImageUploadSubscriber.php
@@ -81,7 +81,7 @@ class ImageUploadSubscriber implements EventSubscriber
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
             if ($entity instanceof ImageInterface){
-                $this->scheduledForCopyImages[] = $entity;
+                $this->scheduledForCopyImages[spl_object_hash($entity)] = $entity;
                 $this->populateMeta($em, $uow, $entity);
             }
         }
@@ -105,11 +105,11 @@ class ImageUploadSubscriber implements EventSubscriber
                     // remove old image
                     $clonedEntity = clone $entity;
                     $clonedEntity->setName($changeSet['name'][0]);
-                    $this->scheduledForDeleteImages[] = $clonedEntity;                  
+                    $this->scheduledForDeleteImages[spl_object_hash($entity)] = $clonedEntity;
                 }
 
                 if (isset($changeSet['hash'])){
-                    $this->scheduledForCopyImages[] = $entity;
+                    $this->scheduledForCopyImages[spl_object_hash($entity)] = $entity;
                 }
                 
                 if(isset($changeSet['name']) || isset($changeSet['hash'])){
@@ -121,7 +121,7 @@ class ImageUploadSubscriber implements EventSubscriber
 
         foreach ($uow->getScheduledEntityDeletions() as $entity) {
             if ($entity instanceof ImageInterface){
-                $this->scheduledForDeleteImages[] = $entity;
+                $this->scheduledForDeleteImages[spl_object_hash($entity)] = $entity;
             }
         }
     }

--- a/Manager/ImageManager.php
+++ b/Manager/ImageManager.php
@@ -177,6 +177,10 @@ class ImageManager extends AbstractManager implements ImageManagerInterface
     public function removeImagesFromTemporaryDirectory(ImageInterface $object)
     {
         try {
+            $name = $object->getName();
+            if(empty($name))
+                return;
+
             $this->temporaryFilesystem->delete($object->getName());
             $this->temporaryFilesystem->delete($this->getTemporaryOriginalImagePath($object->getName()));
         } catch (FileNotFound $e){}        
@@ -188,6 +192,11 @@ class ImageManager extends AbstractManager implements ImageManagerInterface
     public function removeImagesFromPermanentDirectory(ImageInterface $object)
     {   
         try {
+            $name = $object->getName();
+
+            if(empty($name))
+                return;
+
             $this->mediaFilesystem->delete($object->getImagePath());
             $this->mediaFilesystem->delete($this->getPermanentOriginalImagePath($object));
         } catch (FileNotFound $e){}        

--- a/Resources/public/js/image-upload.js
+++ b/Resources/public/js/image-upload.js
@@ -390,8 +390,9 @@ ThraceMedia.imageUpload = function(collection){
                         showError(response.err_msg);
                     } else if(response.success === true) {
                         jQuery('#thrace-image-' + options.id).fadeOut(function(){
+                            var date = new Date().getTime();
                             jQuery(this).attr({
-                                'src': options.render_url + '?name=' + response.name, 
+                                'src': options.render_url + '?name=' + response.name + '&ts=' + date,
                                 'style': 'width:'+ options.minWidth +'px;height:'+ options.minHeight +'px'
                             });
                         }).fadeIn();

--- a/Resources/public/js/image-upload.js
+++ b/Resources/public/js/image-upload.js
@@ -9,9 +9,6 @@ window.ThraceMedia = window.ThraceMedia || {};
 ThraceMedia.imageUpload = function(collection){
     var collection = (collection == undefined) ? jQuery('.thrace-image-upload') : collection;
     
-    // Set no conflict with other libraries
-    jQuery.noConflict();
-    
      // Creates buttons
      jQuery('.thrace-image-upload-button').button();
         
@@ -108,7 +105,7 @@ ThraceMedia.imageUpload = function(collection){
         jQuery('#thrace-image-btn-view-' + options.id).on('click', function(event){
             event.preventDefault();
             jQuery.colorbox({
-                href: options.render_url + '?name=' + jQuery('#' + options.name_id).val(), 
+                href: options.render_url + '?name=' + jQuery('#' + options.name_id).val(),
                 title: jQuery('#' + options.title_id).val()
             });
         });


### PR DESCRIPTION
When user crops the image, it won't refresh due to browser cache (as the URL is the same). Putting a timestamp in the URL will prevent this behaviour.